### PR TITLE
Fix fonts in Kite framework

### DIFF
--- a/App/Project.swift
+++ b/App/Project.swift
@@ -8,10 +8,6 @@ let base = SettingsDictionary()
 let infop: InfoPlist = .extendingDefault(with: [
   "UILaunchStoryboardName": "LaunchScreen",
   "UISupportedInterfaceOrientations": ["UIInterfaceOrientationPortrait"],
-  "UIAppFonts": [
-    "Oxygen-Regularttf", "Oxygen-Light.ttf", "Oxygen-Bold.ttf",
-    "Overpass-Regular.ttf", "Overpass-SemiBold.ttf", "Overpass-Bold.ttf",
-  ],
   "UIApplicationSceneManifest": [
     "UIApplicationSupportsMultipleScenes": false,
     "UISceneConfigurations": [
@@ -47,6 +43,7 @@ let project = Project(
     ),
   ],
   additionalFiles: [
+    "Project.swift",
     "README.md",
   ]
 )

--- a/Kite/Project.swift
+++ b/Kite/Project.swift
@@ -20,6 +20,7 @@ let project = Project(
     ),
   ],
   additionalFiles: [
+    "Project.swift",
     "README.md",
   ]
 )

--- a/Kite/Sources/Tokens/Font.swift
+++ b/Kite/Sources/Tokens/Font.swift
@@ -21,6 +21,11 @@ extension Kite {
   }
 
   public static func font(style: UIFont.TextStyle) -> UIFont {
+    // todo: move to application startup / framework load
+    // hattip https://stackoverflow.com/a/63450699
+    Bundle.module.urls(forResourcesWithExtension: "ttf", subdirectory: nil)?
+      .forEach { url in CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil) }
+
     let size = UIFont.preferredFont(forTextStyle: style).pointSize
     return UIFont(name: Kite.font, size: size)!
   }


### PR DESCRIPTION
### Description

Fonts didn't survive the extraction. The way you load fonts from a Framework
seems to be different from how you load them when they're in the App bundle.
C'est la vie.
