### PR TITLE
feat: add and record wing details

### DIFF
--- a/App/Sources/AppCoordinator.swift
+++ b/App/Sources/AppCoordinator.swift
@@ -18,7 +18,7 @@ class AppCoordinator: Coordinator {
   private var coordinator: Coordinator!
   private let onboarded: Bool
 
-  init(onboarded: Bool = false) {
+  init(onboarded: Bool) {
     self.onboarded = onboarded
     navc = UINavigationController()
     navc.navigationBar.standardAppearance.configureWithTransparentBackground()
@@ -30,6 +30,7 @@ class AppCoordinator: Coordinator {
       coordinator = MainCoordinator(navc: navc)
     } else {
       coordinator = OnboardingCoordinator(navc: navc) {
+        AppContext.shared.repository.setOnboarded(to: true)
         self.coordinator = MainCoordinator(navc: self.navc)
         self.coordinator.start()
       }

--- a/App/Sources/Exercises/ExercisesPage.swift
+++ b/App/Sources/Exercises/ExercisesPage.swift
@@ -131,11 +131,13 @@ extension ExercisesPage: UITableViewDelegate {
       view,
       fn in
       let exercise = self.exercises[indexPath.row]
+      // todo: allow selecting active wing
+      let wing = AppContext.shared.repository.fetchWings()[0]
       let record: Record
       if let placemark = AppServices.shared.location.placemark {
-        record = Record(exerciseId: exercise.id, placemark: placemark)
+        record = Record(exerciseId: exercise.id, wing: wing, placemark: placemark)
       } else {
-        record = Record(exerciseId: exercise.id)
+        record = Record(exerciseId: exercise.id, wing: wing)
       }
       let result = self.repository.save(record: record)
       switch result {

--- a/App/Sources/Exercises/HistoryPage.swift
+++ b/App/Sources/Exercises/HistoryPage.swift
@@ -129,7 +129,7 @@ class RecordRow: UITableViewCell {
     let windLabel = Kite.caption(text: "challenge.history.wind".l)
     let wind = Kite.subhead(text: "\(record.windSpeed)")
     let wingLabel = Kite.caption(text: "challenge.history.wing".l)
-    let wing = Kite.subhead(text: "\(record.wing)")
+    let wing = Kite.subhead(text: "\(record.wing.brand) \(record.wing.name)")
 
     //    map.translatesAutoresizingMaskIntoConstraints = false
     //    map.rounded()

--- a/App/Sources/Onboarding/AddWingPage.swift
+++ b/App/Sources/Onboarding/AddWingPage.swift
@@ -22,10 +22,11 @@ final class AddWingPage: UIViewController, Paged {
 
   init() {
     super.init(nibName: nil, bundle: nil)
-
   }
 
-  private var titleLabelConstraint: NSLayoutConstraint!
+  private var wingBrandField: UITextField!
+  private var wingNameField: UITextField!
+  private var nextButton: UIButton!
 
   override func loadView() {
     let view = Kite.views.background()
@@ -34,35 +35,70 @@ final class AddWingPage: UIViewController, Paged {
     let layout = view.layoutMarginsGuide
 
     let titleLabel = Kite.title(text: "onboarding.addwing.title".l)
-    let textLabel = Kite.body(text: "onboarding.addwing.text".l)
-    let addWingField = UITextField(frame: .zero)
-    addWingField.translatesAutoresizingMaskIntoConstraints = false
-    addWingField.placeholder = "onboarding.addwing.field".l
-    let nextButton = Kite.views.button(
+    view.addSubviews(titleLabel)
+
+    let wingBrandLabel = Kite.body(text: "onboarding.addwing.text".l)
+    wingBrandField = UITextField(frame: .zero)
+    wingBrandField.translatesAutoresizingMaskIntoConstraints = false
+    wingBrandField.placeholder = "onboarding.addwing.brand.placeholder".l
+    view.addSubviews(wingBrandLabel, wingBrandField)
+
+    let wingNameLabel = Kite.body(text: "onboarding.addwing.text".l)
+    wingNameField = UITextField(frame: .zero)
+    wingNameField.translatesAutoresizingMaskIntoConstraints = false
+    wingNameField.placeholder = "onboarding.addwing.name.placeholder".l
+    view.addSubviews(wingNameLabel, wingNameField)
+
+    nextButton = Kite.views.button(
       title: "onboarding.addwing.next".l,
       target: self,
       selector: #selector(nextPage)
     )
-    view.addSubviews(titleLabel, textLabel, nextButton, addWingField)
+    nextButton.isEnabled = false
+    view.addSubviews(nextButton)
 
     NSLayoutConstraint.activate([
       titleLabel.topAnchor.constraint(equalTo: layout.topAnchor),
       titleLabel.centerXAnchor.constraint(equalTo: layout.centerXAnchor),
 
-      textLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor),
-      textLabel.centerXAnchor.constraint(equalTo: layout.centerXAnchor),
+      wingBrandLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor),
+      wingBrandLabel.centerXAnchor.constraint(equalTo: layout.centerXAnchor),
+      wingBrandField.topAnchor.constraint(equalTo: wingBrandLabel.bottomAnchor),
+      wingBrandField.centerXAnchor.constraint(equalTo: layout.centerXAnchor),
 
-      addWingField.topAnchor.constraint(equalTo: textLabel.bottomAnchor),
-      addWingField.centerXAnchor.constraint(equalTo: layout.centerXAnchor),
+      wingNameLabel.topAnchor.constraint(equalTo: wingBrandField.bottomAnchor),
+      wingNameLabel.centerXAnchor.constraint(equalTo: layout.centerXAnchor),
+      wingNameField.topAnchor.constraint(equalTo: wingNameLabel.bottomAnchor),
+      wingNameField.centerXAnchor.constraint(equalTo: layout.centerXAnchor),
 
-      nextButton.topAnchor.constraint(equalTo: addWingField.bottomAnchor),
+      nextButton.topAnchor.constraint(equalTo: wingNameField.bottomAnchor),
       nextButton.centerXAnchor.constraint(equalTo: layout.centerXAnchor),
     ])
 
     self.view = view
   }
 
+  override func viewDidLoad() {
+    wingBrandField.delegate = self
+    wingNameField.delegate = self
+  }
+
   @objc func nextPage() {
+    let wing = Wing(brand: wingBrandField.text!, name: wingNameField.text!)
+    AppContext.shared.repository.save(wing: wing)
     pager?.next(sender: self)
+  }
+}
+
+// MARK: - UITextFieldDelegate
+extension AddWingPage: UITextFieldDelegate {
+  func textField(
+    _ textField: UITextField,
+    shouldChangeCharactersIn range: NSRange,
+    replacementString string: String
+  ) -> Bool {
+    nextButton.isEnabled =
+      (!(wingBrandField.text?.isEmpty ?? false) && !(wingNameField.text?.isEmpty ?? false))
+    return true
   }
 }

--- a/App/Sources/SceneDelegate.swift
+++ b/App/Sources/SceneDelegate.swift
@@ -24,7 +24,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   ) {
     if let windowScene = scene as? UIWindowScene {
       let window = UIWindow(windowScene: windowScene)
-      coordinator = AppCoordinator()
+      coordinator = AppCoordinator(onboarded: AppContext.shared.repository.onboarded)
       window.rootViewController = coordinator.navc
       window.makeKeyAndVisible()
       self.window = window

--- a/App/Sources/Types/Record.swift
+++ b/App/Sources/Types/Record.swift
@@ -17,7 +17,7 @@ struct Record: Codable {
   let id: String
   let date: Date
   let exerciseId: ExerciseId
-  let wing: String?
+  let wing: Wing
   let placemark: Placemark?
   let windSpeed: Measurement<UnitSpeed>?
   let windAngle: Measurement<UnitAngle>?
@@ -28,7 +28,7 @@ struct Record: Codable {
     id: String = UUID().uuidString,
     date: Date = Date(),
     exerciseId: ExerciseId,
-    wing: String? = nil,
+    wing: Wing,
     placemark: Placemark? = nil,
     windSpeed: Measurement<UnitSpeed>? = nil,
     windAngle: Measurement<UnitAngle>? = nil,

--- a/Kite/Sources/Components/Views.swift
+++ b/Kite/Sources/Components/Views.swift
@@ -42,7 +42,8 @@ extension Kite {
       view.setTitle(title, for: .normal)
       view.addTarget(target, action: selector, for: .touchUpInside)
       view.translatesAutoresizingMaskIntoConstraints = false
-      view.setTitleColor(Kite.color.secondary, for: .normal)
+      view.setTitleColor(Kite.color.active, for: .normal)
+      view.setTitleColor(Kite.color.inactive, for: .disabled)
       return view
     }
 


### PR DESCRIPTION
### Description

This adds text fields to add a wing during onboarding, and saves the wing when recording an exercise as complete. We also store whether the user has gone through onboarding so that we show the correct screen at launch.

Plenty of room for improvement: the onboarding and history pages need a lot of ui work, you can't edit a wing after creating it, and we only support one wing. But it's coming together!

closes #40 
