### PR TITLE
build: swift package for siesta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.xcodeproj/
 *.xcworkspace/
+.build/
+.swiftpm/
 Carthage
 Derived/
 build/

--- a/.package.resolved
+++ b/.package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "Alamofire",
-        "repositoryURL": "https://github.com/Alamofire/Alamofire",
-        "state": {
-          "branch": null,
-          "revision": "becd9a729a37bdbef5bc39dc3c702b99f9e3d046",
-          "version": "5.2.2"
-        }
-      },
-      {
         "package": "Cleanse",
         "repositoryURL": "https://github.com/square/Cleanse",
         "state": {
@@ -30,20 +21,11 @@
       },
       {
         "package": "Quick",
-        "repositoryURL": "https://github.com/pcantrell/Quick",
+        "repositoryURL": "https://github.com/Quick/Quick",
         "state": {
           "branch": null,
-          "revision": "39b75c1cd536acb95f643bde93de45e272ccaf86",
-          "version": "0.0.0"
-        }
-      },
-      {
-        "package": "Siesta",
-        "repositoryURL": "https://github.com/bustoutsolutions/siesta",
-        "state": {
-          "branch": null,
-          "revision": "cb9c1bf6dbb89028798b9179fe4d1e1762586057",
-          "version": "1.5.1"
+          "revision": "0038bcbab4292f3b028632556507c124e5ba69f3",
+          "version": "3.0.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Alamofire",
+        "repositoryURL": "https://github.com/Alamofire/Alamofire",
+        "state": {
+          "branch": null,
+          "revision": "9e0328127dfb801cefe8ac53a13c0c90a7770448",
+          "version": "5.4.0"
+        }
+      },
+      {
+        "package": "Siesta",
+        "repositoryURL": "https://github.com/bustoutsolutions/siesta/",
+        "state": {
+          "branch": "bump-swift-package-version",
+          "revision": "c6c2ebcbb884ffc6150d7849b04bbc7aa54cd114",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+  name: "GroundPkg",
+  platforms: [
+    .iOS(.v10),
+    .macOS(.v10_12),
+    .tvOS(.v9),
+  ],
+  products: [
+    .library(name: "KitePkg", targets: ["Kite"])
+  ],
+  dependencies: [
+    .package(
+      name: "Siesta",
+      url: "https://github.com/bustoutsolutions/siesta/",
+      .branch("bump-swift-package-version")
+    )
+  ],
+  targets: [
+    .target(
+      name: "Kite",
+      dependencies: ["Siesta"],
+      path: "Kite/Sources",
+      sources: ["Kite.swift"]
+    )
+  ]
+)

--- a/Project.swift
+++ b/Project.swift
@@ -24,10 +24,9 @@ let infop: InfoPlist = .extendingDefault(with: [
 let project = Project(
   name: "Ground",
   packages: [
+    .package(path: "Siesta"),
     .package(url: "https://github.com/Quick/Nimble", from: "8.0.0"),
-    //.package(url: "https://github.com/Quick/Quick", from: "3.0.0"),
-    .package(url: "https://github.com/bustoutsolutions/siesta", from: "1.5.0"),
-    .package(url: "https://github.com/pcantrell/Quick", .exact("0.0.0")),
+    .package(url: "https://github.com/Quick/Quick", from: "3.0.0"),
     .package(url: "https://github.com/square/Cleanse", from: "4.2.5"),
   ],
   settings: Settings(base: base),

--- a/makefile
+++ b/makefile
@@ -1,7 +1,6 @@
 default:
 	@pkill -f '/Applications/Xcode(-beta)?.app/Contents/MacOS/Xcode' || true
-	@tuist generate
-	@xed .
+	@tuist generate --open
 
 major::
 	@scripts/release.rb major


### PR DESCRIPTION
### Description

This is an attempt at resolving this issue https://github.com/bustoutsolutions/siesta/issues/313
Unfortunately Tuist doesn't support the `.branch` specifier for `.package` dependencies, so I'm trying a workaround of building locally `Siesta` via Swift Package Manager, then having Tuist depend on that.

Work in progress; the `Siesta` artifact isn't in the right place just yet.