### PR TITLE
build: siesta without quick fork

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire",
         "state": {
           "branch": null,
-          "revision": "becd9a729a37bdbef5bc39dc3c702b99f9e3d046",
-          "version": "5.2.2"
+          "revision": "9e0328127dfb801cefe8ac53a13c0c90a7770448",
+          "version": "5.4.0"
         }
       },
       {
@@ -30,20 +30,20 @@
       },
       {
         "package": "Quick",
-        "repositoryURL": "https://github.com/pcantrell/Quick",
+        "repositoryURL": "https://github.com/Quick/Quick",
         "state": {
           "branch": null,
-          "revision": "39b75c1cd536acb95f643bde93de45e272ccaf86",
-          "version": "0.0.0"
+          "revision": "0038bcbab4292f3b028632556507c124e5ba69f3",
+          "version": "3.0.0"
         }
       },
       {
         "package": "Siesta",
         "repositoryURL": "https://github.com/bustoutsolutions/siesta",
         "state": {
-          "branch": null,
-          "revision": "cb9c1bf6dbb89028798b9179fe4d1e1762586057",
-          "version": "1.5.1"
+          "branch": "bump-swift-package-version",
+          "revision": "c6c2ebcbb884ffc6150d7849b04bbc7aa54cd114",
+          "version": null
         }
       }
     ]

--- a/Project.swift
+++ b/Project.swift
@@ -25,9 +25,11 @@ let project = Project(
   name: "Ground",
   packages: [
     .package(url: "https://github.com/Quick/Nimble", from: "8.0.0"),
-    //.package(url: "https://github.com/Quick/Quick", from: "3.0.0"),
-    .package(url: "https://github.com/bustoutsolutions/siesta", from: "1.5.0"),
-    .package(url: "https://github.com/pcantrell/Quick", .exact("0.0.0")),
+    .package(url: "https://github.com/Quick/Quick", from: "3.0.0"),
+    .package(
+      url: "https://github.com/bustoutsolutions/siesta",
+      .branch("bump-swift-package-version")
+    ),
     .package(url: "https://github.com/square/Cleanse", from: "4.2.5"),
   ],
   settings: Settings(base: base),


### PR DESCRIPTION
### Description

As explained in https://github.com/bustoutsolutions/siesta/issues/313 ,
this branch bumps the Swift Package Manager tooling Siesta uses such
that we can use the upstream Quick rather than the version Siesta uses.

closes #53 